### PR TITLE
Adding STSAssumeRoleSessionCredentialsProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,40 @@ The following configuration options are available:
   * Importance: medium
 
 ``s3backed.access.key``
-  AWS access key to use for connecting to S3. Leave empty if AWS credential provider chain should be used.
+  AWS access key to use for connecting to S3. Leave empty if AWS credential provider chain or STS Assume Role provider should be used.
 
   * Type: password
   * Default: ""
   * Importance: low
 
 ``s3backed.secret.key``
-  AWS secret key to use for connecting to S3. Leave empty if AWS credential provider chain should be used.
+  AWS secret key to use for connecting to S3. Leave empty if AWS credential provider chain or STS Assume Role provider should be used.
 
   * Type: password
   * Default: ""
   * Importance: low
+
+ ``s3backed.sts.role.arn``
+   AWS STS role ARN to use for connecting to S3. Leave empty if AWS Basic provider or AWS credential provider chain should be used.
+
+   * Type: string
+   * Default: ""
+   * Importance: low
+
+  
+ ``s3backed.role.external.id``
+   AWS STS role external ID used when retrieving session credentials under an assumed role. Leave empty if AWS Basic provider or AWS credential provider chain should be used.
+
+   * Type: string
+   * Default: ""
+   * Importance: low
+
+ ``s3backed.role.session.name``
+   AWS STS role session name to use when starting a session. Leave empty if AWS Basic provider or AWS credential provider chain should be used.
+
+   * Type: string
+   * Default: ""
+   * Importance: low
 
 ``s3backed.region``
   S3 region to use. Must be configured in conjunction with s3backed.endpoint. Leave empty if default S3 region should be used.

--- a/s3-backed-core/build.gradle.kts
+++ b/s3-backed-core/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
 
     implementation(group = "org.slf4j", name = "slf4j-api", version = "1.7.26")
     api(group = "com.amazonaws", name = "aws-java-sdk-s3", version = "1.11.636")
+    api(group = "com.amazonaws", name = "aws-java-sdk-sts", version = "1.11.636")
     implementation(group = "com.google.guava", name = "guava", version = "28.2-jre")
 
     val junitVersion: String by project


### PR DESCRIPTION
This PR adds the ability to configure the s3 client to use STSAssumeRoleSessionCredentialsProvider.

https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html